### PR TITLE
[WIP] Composed DOM Tweaks

### DIFF
--- a/example/pages/nametag.js
+++ b/example/pages/nametag.js
@@ -1,0 +1,65 @@
+/** @jsx h */
+
+const { Component, define, h, props } = require('skatejs');
+
+const Slant = define(class extends HTMLElement {
+  static is = 'x-slant'
+  connectedCallback () {
+    const slot = document.createElement('slot');
+    const em = document.createElement('em');
+
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(em);
+    em.appendChild(slot);
+  }
+});
+
+const Centered = define(class extends HTMLElement {
+	static is ='x-centered'
+
+	connectedCallback () {
+    const slot = document.createElement('slot');
+    const style = document.createElement('style');
+
+    style.innerHTML = `
+			:host {
+				text-align: center;
+			}
+    `;
+
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(style);
+    this.shadowRoot.appendChild(slot);
+  }
+});
+
+const NameCard = define(class extends Component {
+  static is = 'x-namecard'
+
+  renderCallback () {
+    return (
+      <x-centered>
+      	<h1><slot name="name" /></h1>
+      	<x-slant><slot name="description" /></x-slant>
+      </x-centered>
+    );
+  }
+});
+
+module.exports = define(class extends Component {
+  static is = 'x-index'
+
+  static props = {
+  	name: { ...props.string, default: 'John Doe' },
+  	description: { ...props.string, default: 'Web Components enthusiast' }
+  }
+
+  renderCallback ({ name, description }) {
+    return (
+      <x-namecard>
+      	<p slot="description">{ description }</p>
+        <strong slot="name">{ name }</strong>
+      </x-namecard>
+    );
+  }
+});

--- a/index.js
+++ b/index.js
@@ -5,32 +5,44 @@ function ssrScript (funcName) {
         const script = document.currentScript;
         const host = script.previousElementSibling;
         const fakeShadowRoot = host.firstElementChild;
-        const slotNodes = host.querySelector('slot');
+        const slots = host.getElementsByTagName('slot');
+        const move = (from, to) => { while (from.firstChild) to.appendChild(from.firstChild) };
 
-        // Removing the script speeds up rendering by a few hundred ms when
-        // not optimised and only a few when optimised.
+        // At each Shadow Root, we only care about its slots, not composed slots,
+        // therefore we need to move the children of top level slots, but no others
+        // Also can't 'move' in loop as that will mutate the DOM and ruin the 
+        // 'contains' checks for subsequent slots.
+        const topLevelSlots = (() => {
+          let top = [],
+              ref;
+
+          for (let i = 0, k = slots.length; i < k; i++) {
+            const slot = slots[i];
+
+            // Ref is last known top level slot, if current slot is contained by it,
+            // then that slot is nested and can be ignored
+            if (!(ref && ref.contains(slot))) {
+              top.push(slot);
+              ref = slot;
+            }        
+          }
+
+          return top;
+        })();
+
+        topLevelSlots.forEach(slot => move(slot, host));
+
+        // // Removing the script speeds up rendering by a few hundred ms when
+        // // not optimised and only a few when optimised.
         script.parentNode.removeChild(script);
 
         // The fastest overall method is to simply use innerHTML. This seems to be
         // faster when not optimised (by about 50%) but is slightly slower when
         // optimised compared to traversing the fake shadow root and appending each
         // element to the real one:
-        //
-        // const realShadowRoot = host.attachShadow({ mode: 'open' });
-        // while (fakeShadowRoot.firstChild) realShadowRoot.appendChild(fakeShadowRoot.firstChild);
-        host.attachShadow({ mode: 'open' }).innerHTML = fakeShadowRoot.innerHTML;
-
-        // Ensure slotted content is appended as light DOM content.
-        for (let a = 0; a < slotNodes.length; a++) {
-          const slotNode = slotNode[a];
-          if (slotNode.hasAttribute('default')) {
-            slotNode.removeAttribute('default');
-          } else {
-            while (slotNode.firstChild) {
-              host.appendChild(slotNode.firstChild);
-            }
-          }
-        }
+        const realShadowRoot = host.attachShadow({ mode: 'open' });
+        move(fakeShadowRoot, realShadowRoot);
+        host.removeChild(fakeShadowRoot);
       }
     </script>
   `;

--- a/perf/use-script-composed.html
+++ b/perf/use-script-composed.html
@@ -1,0 +1,61 @@
+<script src="./index.js"></script>
+<script>
+  function __ssr () {
+    const script = document.currentScript;
+    const host = script.previousElementSibling;
+    const fakeShadowRoot = host.firstElementChild;
+    const slots = host.getElementsByTagName('slot');
+    const move = (from, to) => { while (from.firstChild) to.appendChild(from.firstChild) };
+
+    // At each Shadow Root, we only care about its slots, not composed slots,
+    // therefore we need to move the children of top level slots, but no others
+    // Also can't 'move' in loop as that will mutate the DOM and ruin the 
+    // 'contains' checks for subsequent slots.
+    const topLevelSlots = (() => {
+      let top = [],
+          ref;
+
+      for (let i = 0, k = slots.length; i < k; i++) {
+        const slot = slots[i];
+
+        // Ref is last known top level slot, if current slot is contained by it,
+        // then that slot is nested and can be ignored
+        if (!(ref && ref.contains(slot))) {
+          top.push(slot);
+          ref = slot;
+        }        
+      }
+
+      return top;
+    })();
+
+    topLevelSlots.forEach(slot => move(slot, host));
+
+    // // Removing the script speeds up rendering by a few hundred ms when
+    // // not optimised and only a few when optimised.
+    script.parentNode.removeChild(script);
+
+    // The fastest overall method is to simply use innerHTML. This seems to be
+    // faster when not optimised (by about 50%) but is slightly slower when
+    // optimised compared to traversing the fake shadow root and appending each
+    // element to the real one:
+    const realShadowRoot = host.attachShadow({ mode: 'open' });
+    move(fakeShadowRoot, realShadowRoot);
+    host.removeChild(fakeShadowRoot);
+  }
+</script>
+<script>
+  test(a => {
+    const frag = document.createDocumentFragment();
+    const div = document.createElement('div');
+    const script = document.createElement('script');
+
+    div.innerHTML = `<shadow-root><strong><slot>${a}</slot></strong></shadow-root>`;
+    script.innerHTML = `__ssr();`;
+
+    frag.appendChild(div);
+    frag.appendChild(script);
+
+    return frag;
+  });
+</script>

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,3 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render (serialisation) renders correctly 1`] = `"<script>function __ssr(){var a=document.currentScript.previousElementSibling,b=a.firstElementChild;a.removeChild(b);for(var c=a.attachShadow({mode:\\"open\\"});b.hasChildNodes();)c.appendChild(b.firstChild);}</script><x-hello><shadow-root><span>Hello, <x-yell><shadow-root><strong><slot></slot></strong></shadow-root><slot></slot></x-yell><script>__ssr()</script>!</span></shadow-root>World</x-hello><script>__ssr()</script>"`;
+exports[`render (serialisation) renders correctly 1`] = `
+"
+    <script>
+      function __ssr () {
+        const script = document.currentScript;
+        const host = script.previousElementSibling;
+        const fakeShadowRoot = host.firstElementChild;
+        const slots = host.getElementsByTagName('slot');
+        const move = (from, to) => { while (from.firstChild) to.appendChild(from.firstChild) };
+
+        // At each Shadow Root, we only care about its slots, not composed slots,
+        // therefore we need to move the children of top level slots, but no others
+        // Also can't 'move' in loop as that will mutate the DOM and ruin the 
+        // 'contains' checks for subsequent slots.
+        const topLevelSlots = (() => {
+          let top = [],
+              ref;
+
+          for (let i = 0, k = slots.length; i < k; i++) {
+            const slot = slots[i];
+
+            // Ref is last known top level slot, if current slot is contained by it,
+            // then that slot is nested and can be ignored
+            if (!(ref && ref.contains(slot))) {
+              top.push(slot);
+              ref = slot;
+            }        
+          }
+
+          return top;
+        })();
+
+        topLevelSlots.forEach(slot => move(slot, host));
+
+        // // Removing the script speeds up rendering by a few hundred ms when
+        // // not optimised and only a few when optimised.
+        script.parentNode.removeChild(script);
+
+        // The fastest overall method is to simply use innerHTML. This seems to be
+        // faster when not optimised (by about 50%) but is slightly slower when
+        // optimised compared to traversing the fake shadow root and appending each
+        // element to the real one:
+        const realShadowRoot = host.attachShadow({ mode: 'open' });
+        move(fakeShadowRoot, realShadowRoot);
+        host.removeChild(fakeShadowRoot);
+      }
+    </script>
+  <x-hello><shadow-root><span>Hello, <x-yell><shadow-root><strong><slot><slot>World</slot></slot></strong></shadow-root></x-yell><script>__ssr()</script>!</span></shadow-root></x-hello><script>__ssr()</script>"
+`;


### PR DESCRIPTION
This iterates on the original composed DOM branch to try address #6. Mainly, it patches the hydration script to work with nested / named slots. But it also adds in a composed benchmark (doesn't look like it adds much overhead 🎉 ) and also an example which uses named slots.

Still needs to address default slot content - I haven't looked into it yet, but looks like we'll need a way to store both the light and default DOM inside the slot. I'd say wrapping it in a 'slot-default' node and unwrapping it while hydrating that particular slot is the way to go. Also needs to be generally cleaned up and tested.