### PR TITLE
Fix commas inserted between multiple attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ function stringifyAll(nodes, opts, currentShadowRoot) {
 function stringifyAttributes(attributes) {
   return Array.from(attributes || []).map(
     ({ name, value }) => ` ${name}="${value}"`
-  );
+  ).join('');
 }
 
 function createElement(name, props) {


### PR DESCRIPTION
Wrong array stringification caused commas to be inserted if there was more than one attribute on an element.

Example:
```html
<html><head>
    <title>Solid State by HTML5 UP</title>
    <meta charset="utf-8"></meta>
    <meta name="viewport", content="width=device-width, initial-scale=1"></meta>
    <link rel="stylesheet", href="assets/css/main.css"></link>
...
```